### PR TITLE
A quick bug fix to force a refresh and update of log-groups when the …

### DIFF
--- a/client/src/components/LeftDrawer/LeftDrawer.js
+++ b/client/src/components/LeftDrawer/LeftDrawer.js
@@ -48,7 +48,9 @@ class LeftDrawer extends Component<Props, State> {
     }
 
     componentWillReceiveProps(nextProps){
-        this.setState({logGroups: nextProps.logGroups})
+        this.setState({logGroups: nextProps.logGroups},()=>{
+            this.searchLogGroups({target:{value: this.state.searchLogGroups }});
+        })
     }
 
     componentDidMount(){
@@ -58,6 +60,7 @@ class LeftDrawer extends Component<Props, State> {
             if (this.props.autoRefresh ) {
                 setInterval( ()=>{ this.getLogs() }, this.props.autoRefreshInt)
             }
+            this.fetchLogGroups();
         });
     }
 
@@ -68,6 +71,8 @@ class LeftDrawer extends Component<Props, State> {
         this.setState({
             dropDownValue: value,
             filteredLogGroups: this.filterLogGroups( this.state.logGroupSearchValue, value)
+        }, ()=>{
+            this.fetchLogGroups();
         });
     }
 

--- a/main.js
+++ b/main.js
@@ -143,7 +143,7 @@ function checkForUpdates(){
 let win;
 
 function createWindow () {
-    app.dock.setBadge('Hi!👋')
+    app.dock.setBadge('Hi!👋');
     // const menu = Menu.buildFromTemplate(template); //todo: uncomment these two lines and add copy/paste to the application menu ( https://github.com/electron/electron/issues/4107 )
     // Menu.setApplicationMenu(menu);
 


### PR DESCRIPTION
…app is opened for the first time ( previously was showing an empty list and the user had to switch between log group, if any, and/or restart the app for it to show the list properly )